### PR TITLE
Increase iOS minimum supported version to v9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSVG",
-    platforms: [.macOS(.v10_14), .iOS(.v8), .tvOS(.v9)],
+    platforms: [.macOS(.v10_14), .iOS(.v9), .tvOS(.v9)],
     products: [
         .library(
             name: "SwiftSVG",


### PR DESCRIPTION
Versions of iOS below 9 are no longer supported, as of XCode 13